### PR TITLE
Fix BaseSettings import for pydantic 2+

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     ttl: int = 300

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ cachetools
 python-dotenv
 pytest
 pytest-cov
+pydantic>=2.0
+pydantic-settings>=2.0


### PR DESCRIPTION
## Summary
- update BaseSettings import to use pydantic-settings
- add pydantic and pydantic-settings to backend requirements

## Testing
- `pytest backend/tests/test_market_indices.py` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685ea1fab5fc8324b0b1f3c4ac3053d4