### PR TITLE
Fix CI tests by mocking yfinance

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pytest
 pytest-cov
 pydantic>=2.0
 pydantic-settings>=2.0
+pytest-mock

--- a/backend/tests/test_market_indices.py
+++ b/backend/tests/test_market_indices.py
@@ -1,7 +1,15 @@
 from app.crud import fetch_market_indices
 
 
-def test_market_values_positive():
+def test_market_values_positive(mocker):
+    """fetch_market_indices should aggregate mocked yfinance data"""
+    mock_ticker = mocker.patch("yfinance.Ticker")
+    mock_ticker.return_value.fast_info = {
+        "last_price": 100,
+        "last_volume": 1_000_000,
+    }
+
     data = fetch_market_indices()
-    assert data.dxy_proxy_uup.value > 0
-    assert data.volume_aggregated.value > 0
+
+    assert data.dxy_proxy_uup.value == 100
+    assert data.volume_aggregated.value == 2_000_000


### PR DESCRIPTION
## Summary
- add `pytest-mock` to backend requirements
- mock `yfinance.Ticker` in `test_market_indices`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685ea501c4608324af28338a5822c295