### PR TITLE
Implement latest_macro endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ BEA_API_KEY=xxxxxxxxxxxxxxxx
 | Route                    | Méthode | Description                                       |
 | ------------------------ | ------- | ------------------------------------------------- |
 | `/api/v1/market_indices` | GET     | Retourne **DXY (UUP)** et **Volume US** (SPY+QQQ) |
+| `/api/v1/latest_macro`   | GET     | Dernière statistique CPI ou NFP publiée |
 
-`/api/v1/fed_rate`, `/api/v1/vix`, `/api/v1/latest_macro` … seront ajoutés dans les tickets suivants.
+`/api/v1/fed_rate`, `/api/v1/vix` … seront ajoutés dans les tickets suivants.
 
 ## 🛠️ Build & déploiement VPS
 
@@ -73,7 +74,7 @@ BEA_API_KEY=xxxxxxxxxxxxxxxx
 ## ✅ Feuille de route courte
 
 * [x] Ticket #1 — Base FastAPI + endpoint market\_indices (yfinance)
-* [ ] Ticket #2 — Endpoints CPI/NFP (BLS)
+* [x] Ticket #2 — Endpoints CPI/NFP (BLS)
 * [ ] Ticket #3 — Endpoint PCE (BEA)
 * [ ] Ticket #4 — Endpoints FED rate & VIX (FRED)
 * [ ] Ticket #5 — Service systemd + Nginx conf

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,2 @@
 
+BLS_API_KEY=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     ttl: int = 300
+    bls_api_key: str | None = None
 
     class Config:
         env_file = '.env'

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 
-from .crud import fetch_market_indices
-from .schemas import MarketIndices
+from .crud import fetch_market_indices, fetch_latest_macro
+from .schemas import MarketIndices, LatestMacro
 
 app = FastAPI(title="Goldapp API")
 
@@ -10,5 +10,13 @@ app = FastAPI(title="Goldapp API")
 def get_market_indices():
     try:
         return fetch_market_indices()
+    except Exception:
+        raise HTTPException(status_code=503, detail="Data source unavailable")
+
+
+@app.get("/api/v1/latest_macro", response_model=LatestMacro)
+def get_latest_macro():
+    try:
+        return fetch_latest_macro()
     except Exception:
         raise HTTPException(status_code=503, detail="Data source unavailable")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,3 +10,15 @@ class Indicator(BaseModel):
 class MarketIndices(BaseModel):
     dxy_proxy_uup: Indicator
     volume_aggregated: Indicator
+
+
+class MacroStat(BaseModel):
+    name: str
+    value: float
+    unit: str
+    date: str
+    source: str
+
+
+class LatestMacro(BaseModel):
+    latest_macro: MacroStat

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 yfinance
+requests
 cachetools
 python-dotenv
 pytest

--- a/backend/tests/test_latest_macro.py
+++ b/backend/tests/test_latest_macro.py
@@ -1,0 +1,46 @@
+import requests
+
+import pytest
+
+from app.crud import fetch_latest_macro, MACRO_CACHE
+
+
+def _mock_response(mocker, payload):
+    resp = mocker.Mock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_latest_macro_success(mocker):
+    """Return the most recent between CPI and NFP."""
+    MACRO_CACHE.clear()
+    mock_get = mocker.patch("requests.get")
+
+    cpi_payload = {
+        "Results": {"series": [{"data": [{"year": "2024", "period": "M05", "value": "310"}]}]}
+    }
+    nfp_payload = {
+        "Results": {"series": [{"data": [{"year": "2024", "period": "M06", "value": "150000"}]}]}
+    }
+
+    mock_get.side_effect = [
+        _mock_response(mocker, cpi_payload),
+        _mock_response(mocker, nfp_payload),
+    ]
+
+    data = fetch_latest_macro()
+
+    assert data.latest_macro.name == "NFP"
+    assert data.latest_macro.date == "2024-06"
+    assert data.latest_macro.unit == "k jobs"
+
+
+def test_latest_macro_unavailable(mocker):
+    """Any request error should bubble up as RuntimeError."""
+    MACRO_CACHE.clear()
+    mock_get = mocker.patch("requests.get", side_effect=requests.RequestException)
+
+    with pytest.raises(RuntimeError):
+        fetch_latest_macro()
+


### PR DESCRIPTION
## Summary
- add BLS API key support in settings
- integrate CPI and NFP retrieval through BLS
- expose `/api/v1/latest_macro` endpoint
- document endpoint and update roadmap
- add tests for the new fetch function
- include requests in dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ea6ccd5e88324881677793c888675