### PR TITLE
Implement BEA PCE endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,3 @@
 
 BLS_API_KEY=
+BEA_API_KEY=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,11 +1,14 @@
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
     ttl: int = 300
     bls_api_key: str | None = None
+    bea_api_key: str | None = None
 
     class Config:
-        env_file = '.env'
-        env_file_encoding = 'utf-8'
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 
-from .crud import fetch_market_indices, fetch_latest_macro
-from .schemas import MarketIndices, LatestMacro
+from .crud import fetch_market_indices, fetch_latest_macro, fetch_pce
+from .schemas import MarketIndices, LatestMacro, PCEStat
 
 app = FastAPI(title="Goldapp API")
 
@@ -20,3 +20,12 @@ def get_latest_macro():
         return fetch_latest_macro()
     except Exception:
         raise HTTPException(status_code=503, detail="Data source unavailable")
+
+
+@app.get("/api/v1/pce", response_model=PCEStat)
+def get_pce():
+    try:
+        return fetch_pce()
+    except Exception:
+        raise HTTPException(status_code=503, detail="Data source unavailable")
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,11 +1,13 @@
 from pydantic import BaseModel
 from datetime import datetime
 
+
 class Indicator(BaseModel):
     symbol: str
     value: float
     unit: str
     last_updated_utc: datetime
+
 
 class MarketIndices(BaseModel):
     dxy_proxy_uup: Indicator
@@ -13,6 +15,14 @@ class MarketIndices(BaseModel):
 
 
 class MacroStat(BaseModel):
+    name: str
+    value: float
+    unit: str
+    date: str
+    source: str
+
+
+class PCEStat(BaseModel):
     name: str
     value: float
     unit: str

--- a/backend/tests/test_pce.py
+++ b/backend/tests/test_pce.py
@@ -1,0 +1,55 @@
+import requests
+import pytest
+
+from app.crud import fetch_pce, PCE_CACHE
+from app.config import settings
+
+
+def _mock_response(mocker, payload):
+    resp = mocker.Mock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_pce_success(mocker):
+    """fetch_pce should return the most recent PCE value."""
+    PCE_CACHE.clear()
+    mock_get = mocker.patch("requests.get")
+    payload = {
+        "BEAAPI": {
+            "Results": {
+                "Data": [
+                    {"TimePeriod": "2024M04", "DataValue": "0.2"},
+                    {"TimePeriod": "2024M05", "DataValue": "0.1"},
+                ]
+            }
+        }
+    }
+    mock_get.return_value = _mock_response(mocker, payload)
+    mocker.patch.object(settings, "bea_api_key", "KEY")
+
+    data = fetch_pce()
+
+    assert data.name == "PCE"
+    assert data.value == 0.1
+    assert data.date == "2024-05"
+    assert data.unit == "%"
+    assert data.source == "BEA"
+
+
+def test_pce_no_key(mocker):
+    """Missing API key should raise RuntimeError."""
+    PCE_CACHE.clear()
+    mocker.patch.object(settings, "bea_api_key", None)
+    with pytest.raises(RuntimeError):
+        fetch_pce()
+
+
+def test_pce_unavailable(mocker):
+    """Network issues should bubble up as RuntimeError."""
+    PCE_CACHE.clear()
+    mocker.patch.object(settings, "bea_api_key", "KEY")
+    mocker.patch("requests.get", side_effect=requests.RequestException)
+    with pytest.raises(RuntimeError):
+        fetch_pce()


### PR DESCRIPTION
## Summary
- support BEA_API_KEY in settings and env example
- create `PCEStat` schema
- implement BEA call in CRUD and expose `fetch_pce`
- add REST route `/api/v1/pce`
- provide unit tests for PCE logic

## Testing
- `black app tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ea9a0681c8324b2e768d49de7ad96