### PR TITLE
Fix blank lines to satisfy E302

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ def get_market_indices():
     except Exception:
         raise HTTPException(status_code=503, detail="Data source unavailable")
 
+
 @app.get("/api/v1/latest_macro", response_model=LatestMacro)
 def get_latest_macro():
     try:


### PR DESCRIPTION
## Summary
- ensure two blank lines before `get_latest_macro`

## Testing
- `python -m flake8 backend/app/` *(fails: No module named flake8)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685eb32301708324b75346e0e469044e