### PR TITLE
Fix HTTP endpoint tests by using ASGITransport

### DIFF
--- a/backend/tests/test_endpoints_http.py
+++ b/backend/tests/test_endpoints_http.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 from app.main import app
 from app.schemas import (
@@ -17,7 +17,8 @@ from app.schemas import (
 async def test_api_market_indices_ok(mocker):
     mock_ticker = mocker.patch("yfinance.Ticker")
     mock_ticker.return_value.fast_info = {"last_price": 1, "last_volume": 2}
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/market_indices")
     assert resp.status_code == 200
     data = resp.json()
@@ -27,7 +28,8 @@ async def test_api_market_indices_ok(mocker):
 @pytest.mark.asyncio
 async def test_api_market_indices_error(mocker):
     mocker.patch("yfinance.Ticker", side_effect=Exception)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/market_indices")
     assert resp.status_code == 503
 
@@ -36,7 +38,8 @@ async def test_api_market_indices_error(mocker):
 async def test_api_latest_macro_ok(mocker):
     payload = LatestMacro(latest_macro=MacroStat(name="CPI", value=1.0, unit="i", date="2024-06", source="BLS"))
     mocker.patch("app.crud.fetch_latest_macro", return_value=payload)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/latest_macro")
     assert resp.status_code == 200
     assert resp.json()["latest_macro"]["name"] == "CPI"
@@ -45,7 +48,8 @@ async def test_api_latest_macro_ok(mocker):
 @pytest.mark.asyncio
 async def test_api_latest_macro_error(mocker):
     mocker.patch("app.crud.fetch_latest_macro", side_effect=RuntimeError)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/latest_macro")
     assert resp.status_code == 503
 
@@ -54,7 +58,8 @@ async def test_api_latest_macro_error(mocker):
 async def test_api_pce_ok(mocker):
     payload = PCEStat(name="PCE", value=0.1, unit="%", date="2024-06", source="BEA")
     mocker.patch("app.crud.fetch_pce", return_value=payload)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/pce")
     assert resp.status_code == 200
     assert resp.json()["source"] == "BEA"
@@ -63,7 +68,8 @@ async def test_api_pce_ok(mocker):
 @pytest.mark.asyncio
 async def test_api_pce_error(mocker):
     mocker.patch("app.crud.fetch_pce", side_effect=RuntimeError)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/pce")
     assert resp.status_code == 503
 
@@ -72,7 +78,8 @@ async def test_api_pce_error(mocker):
 async def test_api_fed_rate_ok(mocker):
     payload = FedRate(value=5.0, date="2024-06-13")
     mocker.patch("app.crud.fetch_fed_rate", return_value=payload)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/fed_rate")
     assert resp.status_code == 200
     assert resp.json()["source"] == "FRED"
@@ -81,7 +88,8 @@ async def test_api_fed_rate_ok(mocker):
 @pytest.mark.asyncio
 async def test_api_fed_rate_error(mocker):
     mocker.patch("app.crud.fetch_fed_rate", side_effect=RuntimeError)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/fed_rate")
     assert resp.status_code == 503
 
@@ -90,7 +98,8 @@ async def test_api_fed_rate_error(mocker):
 async def test_api_vix_ok(mocker):
     payload = VIXClose(value=15.5, date="2024-06-14")
     mocker.patch("app.crud.fetch_vix", return_value=payload)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/vix")
     assert resp.status_code == 200
     assert resp.json()["source"] == "FRED"
@@ -99,6 +108,7 @@ async def test_api_vix_ok(mocker):
 @pytest.mark.asyncio
 async def test_api_vix_error(mocker):
     mocker.patch("app.crud.fetch_vix", side_effect=RuntimeError)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/vix")
     assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- import ASGITransport for `AsyncClient`
- use ASGITransport in all HTTP endpoint tests

## Testing
- `pytest backend/tests/test_endpoints_http.py::test_api_market_indices_ok -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eb589808c8324985cfb7b2e6c3957