### PR TITLE
Fix endpoints error handling and mock paths

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,38 +15,53 @@ app = FastAPI(title="Goldapp API")
 @app.get("/api/v1/market_indices", response_model=MarketIndices)
 def get_market_indices():
     try:
-        return fetch_market_indices()
+        data = fetch_market_indices()
     except Exception:
-        raise HTTPException(status_code=503, detail="Data source unavailable")
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
 
 
 @app.get("/api/v1/latest_macro", response_model=LatestMacro)
 def get_latest_macro():
     try:
-        return fetch_latest_macro()
+        data = fetch_latest_macro()
     except Exception:
-        raise HTTPException(status_code=503, detail="Data source unavailable")
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
 
 
 @app.get("/api/v1/pce", response_model=PCEStat)
 def get_pce():
     try:
-        return fetch_pce()
+        data = fetch_pce()
     except Exception:
-        raise HTTPException(status_code=503, detail="Data source unavailable")
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
 
 
 @app.get("/api/v1/fed_rate", response_model=FedRate)
 def get_fed_rate():
     try:
-        return fetch_fed_rate()
+        data = fetch_fed_rate()
     except Exception:
-        raise HTTPException(status_code=503, detail="Data source unavailable")
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
 
 
 @app.get("/api/v1/vix", response_model=VIXClose)
 def get_vix():
     try:
-        return fetch_vix()
+        data = fetch_vix()
     except Exception:
-        raise HTTPException(status_code=503, detail="Data source unavailable")
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data

--- a/backend/tests/test_endpoints_http.py
+++ b/backend/tests/test_endpoints_http.py
@@ -37,7 +37,7 @@ async def test_api_market_indices_error(mocker):
 @pytest.mark.asyncio
 async def test_api_latest_macro_ok(mocker):
     payload = LatestMacro(latest_macro=MacroStat(name="CPI", value=1.0, unit="i", date="2024-06", source="BLS"))
-    mocker.patch("app.crud.fetch_latest_macro", return_value=payload)
+    mocker.patch("app.main.fetch_latest_macro", return_value=payload)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/latest_macro")
@@ -47,7 +47,7 @@ async def test_api_latest_macro_ok(mocker):
 
 @pytest.mark.asyncio
 async def test_api_latest_macro_error(mocker):
-    mocker.patch("app.crud.fetch_latest_macro", side_effect=RuntimeError)
+    mocker.patch("app.main.fetch_latest_macro", side_effect=RuntimeError)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/latest_macro")
@@ -57,7 +57,7 @@ async def test_api_latest_macro_error(mocker):
 @pytest.mark.asyncio
 async def test_api_pce_ok(mocker):
     payload = PCEStat(name="PCE", value=0.1, unit="%", date="2024-06", source="BEA")
-    mocker.patch("app.crud.fetch_pce", return_value=payload)
+    mocker.patch("app.main.fetch_pce", return_value=payload)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/pce")
@@ -67,7 +67,7 @@ async def test_api_pce_ok(mocker):
 
 @pytest.mark.asyncio
 async def test_api_pce_error(mocker):
-    mocker.patch("app.crud.fetch_pce", side_effect=RuntimeError)
+    mocker.patch("app.main.fetch_pce", side_effect=RuntimeError)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/pce")
@@ -77,7 +77,7 @@ async def test_api_pce_error(mocker):
 @pytest.mark.asyncio
 async def test_api_fed_rate_ok(mocker):
     payload = FedRate(value=5.0, date="2024-06-13")
-    mocker.patch("app.crud.fetch_fed_rate", return_value=payload)
+    mocker.patch("app.main.fetch_fed_rate", return_value=payload)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/fed_rate")
@@ -87,7 +87,7 @@ async def test_api_fed_rate_ok(mocker):
 
 @pytest.mark.asyncio
 async def test_api_fed_rate_error(mocker):
-    mocker.patch("app.crud.fetch_fed_rate", side_effect=RuntimeError)
+    mocker.patch("app.main.fetch_fed_rate", side_effect=RuntimeError)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/fed_rate")
@@ -97,7 +97,7 @@ async def test_api_fed_rate_error(mocker):
 @pytest.mark.asyncio
 async def test_api_vix_ok(mocker):
     payload = VIXClose(value=15.5, date="2024-06-14")
-    mocker.patch("app.crud.fetch_vix", return_value=payload)
+    mocker.patch("app.main.fetch_vix", return_value=payload)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/vix")
@@ -107,7 +107,7 @@ async def test_api_vix_ok(mocker):
 
 @pytest.mark.asyncio
 async def test_api_vix_error(mocker):
-    mocker.patch("app.crud.fetch_vix", side_effect=RuntimeError)
+    mocker.patch("app.main.fetch_vix", side_effect=RuntimeError)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/vix")


### PR DESCRIPTION
## Summary
- ensure each FastAPI route handles exceptions and `None` returns
- patch endpoint tests using the import path from `app.main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eb8bff8ec8324b336a55602a70e99