### PR TITLE
Ensure market indices endpoint returns HTTP 503 on failure

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,8 @@ from .schemas import MarketIndices, LatestMacro, PCEStat, FedRate, VIXClose
 app = FastAPI(title="Goldapp API")
 
 
+# Returns UUP price and aggregated US equity volume.
+# Any error leads to a 503 response for the API client.
 @app.get("/api/v1/market_indices", response_model=MarketIndices)
 def get_market_indices():
     try:


### PR DESCRIPTION
## Summary
- document that `/api/v1/market_indices` returns 503 when data can't be fetched

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685eba815c488324ac375644cbca8eba