### PR TITLE
Fix docs on sync market indices handler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,12 @@ app = FastAPI(title="Goldapp API")
 
 # Returns UUP price and aggregated US equity volume.
 # Any error leads to a 503 response for the API client.
+#
+# NOTE: fetch_market_indices() is a synchronous function. The FastAPI handler
+# must therefore remain synchronous to ensure exceptions raised by the CRUD
+# layer propagate correctly to the client. Declaring this handler as
+# ``async`` would cause FastAPI to swallow sync exceptions and return HTTP 200
+# instead of 503 in tests.
 @app.get("/api/v1/market_indices", response_model=MarketIndices)
 def get_market_indices():
     try:


### PR DESCRIPTION
## Summary
- document why `get_market_indices` must remain synchronous

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685ebca752a88324a9988bd34e5fa415