### PR TITLE
Implement /api/v1/fomc_next endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ BEA_API_KEY=xxxxxxxxxxxxxxxx
 | `/api/v1/pce`            | GET     | Variation mensuelle du PCE |
 | `/api/v1/fed_rate`       | GET     | Dernier taux directeur de la FED |
 | `/api/v1/vix`            | GET     | Clôture quotidienne du VIX |
+| `/api/v1/fomc_next`      | GET     | Prochaine réunion FOMC |
+
+Exemple de réponse :
+
+```json
+{
+  "date": "2024-07-31",
+  "time": "18:00",
+  "title": "FOMC Meeting",
+  "url": "https://www.federalreserve.gov/..."
+}
+```
 
 ## 🛠️ Build & déploiement VPS
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,8 +6,16 @@ from .crud import (
     fetch_pce,
     fetch_fed_rate,
     fetch_vix,
+    fetch_fomc_next,
 )
-from .schemas import MarketIndices, LatestMacro, PCEStat, FedRate, VIXClose
+from .schemas import (
+    MarketIndices,
+    LatestMacro,
+    PCEStat,
+    FedRate,
+    VIXClose,
+    FomcNext,
+)
 
 app = FastAPI(title="Goldapp API")
 
@@ -71,5 +79,15 @@ def get_vix():
     except Exception:
         raise HTTPException(status_code=503, detail="Service Unavailable")
     if data is None:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
+
+
+@app.get("/api/v1/fomc_next", response_model=FomcNext | None)
+def get_fomc_next():
+    """Return the next upcoming FOMC meeting."""
+    try:
+        data = fetch_fomc_next()
+    except Exception:
         raise HTTPException(status_code=503, detail="Service Unavailable")
     return data

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -44,3 +44,12 @@ class VIXClose(BaseModel):
     value: float
     date: str
     source: str = "FRED"
+
+
+class FomcNext(BaseModel):
+    """Represent the next scheduled FOMC meeting."""
+
+    date: str  # YYYY-MM-DD
+    time: str  # HH:MM (UTC)
+    title: str
+    url: str

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,4 +1,4 @@
-from app.crud import fetch_market_indices, CACHE
+from app.crud import fetch_market_indices, CACHE, fetch_fomc_next, FOMC_NEXT_CACHE
 
 
 def test_market_indices_cache(mocker):
@@ -9,3 +9,18 @@ def test_market_indices_cache(mocker):
     second = fetch_market_indices()
     assert first is second
     assert mock_ticker.call_count == 3
+
+
+def test_fomc_next_cache(mocker):
+    FOMC_NEXT_CACHE.clear()
+    mock_get = mocker.patch("requests.get")
+    mock_get.return_value.text = (
+        "<rss><channel>"
+        "<item><title>A</title><link>u</link><start>2099-01-01T00:00:00Z</start></item>"
+        "</channel></rss>"
+    )
+    mock_get.return_value.raise_for_status.return_value = None
+    first = fetch_fomc_next()
+    second = fetch_fomc_next()
+    assert first is second
+    assert mock_get.call_count == 1

--- a/backend/tests/test_fomc_next.py
+++ b/backend/tests/test_fomc_next.py
@@ -1,0 +1,63 @@
+import requests
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.crud import fetch_fomc_next, FOMC_NEXT_CACHE
+from app.schemas import FomcNext
+
+
+def _mock_response(mocker, text: str):
+    resp = mocker.Mock()
+    resp.text = text
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_fomc_next_success(mocker):
+    FOMC_NEXT_CACHE.clear()
+    now = datetime.utcnow()
+    dt1 = (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    dt2 = (now + timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    xml = f"""
+    <rss><channel>
+        <item><title>First</title><link>https://a</link><start>{dt1}</start></item>
+        <item><title>Second</title><link>https://b</link><start>{dt2}</start></item>
+    </channel></rss>
+    """
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+
+    data = fetch_fomc_next()
+
+    assert isinstance(data, FomcNext)
+    assert data.title == "First"
+    assert data.url == "https://a"
+    assert data.date == (now + timedelta(days=1)).strftime("%Y-%m-%d")
+    assert data.time == (now + timedelta(days=1)).strftime("%H:%M")
+
+
+def test_fomc_next_none(mocker):
+    FOMC_NEXT_CACHE.clear()
+    now = datetime.utcnow()
+    past = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    xml = f"<rss><channel><item><title>Past</title><link>x</link><start>{past}</start></item></channel></rss>"
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+
+    data = fetch_fomc_next()
+
+    assert data is None
+
+
+def test_fomc_next_error(mocker):
+    FOMC_NEXT_CACHE.clear()
+    mocker.patch("requests.get", side_effect=requests.RequestException)
+    with pytest.raises(RuntimeError):
+        fetch_fomc_next()
+
+
+def test_fomc_next_parse_error(mocker):
+    FOMC_NEXT_CACHE.clear()
+    xml = "<rss><channel><item>"
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+    with pytest.raises(RuntimeError):
+        fetch_fomc_next()


### PR DESCRIPTION
## Summary
- add `FomcNext` schema
- implement `fetch_fomc_next` with 24h caching
- expose new `/api/v1/fomc_next` route
- document the endpoint
- add unit tests for parser, cache and route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa55078083248477cfa9cc10eb54