### PR TITLE
Fix timezone-aware comparison in FOMC fetcher

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from xml.etree import ElementTree
 from cachetools import cached, TTLCache
 import requests
@@ -216,7 +216,7 @@ def fetch_fomc_next() -> FomcNext | None:
     try:
         root = ElementTree.fromstring(xml_text)
         items = root.findall(".//item")
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         for item in items:
             start_text = item.findtext("start")
             if not start_text:


### PR DESCRIPTION
## Summary
- ensure fetch_fomc_next uses timezone-aware `now`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - pip packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6863bcb851288324b12f8b54b1675a39