### PR TITLE
Implement Powell speech endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ BEA_API_KEY=xxxxxxxxxxxxxxxx
 | `/api/v1/fed_rate`       | GET     | Dernier taux directeur de la FED |
 | `/api/v1/vix`            | GET     | Clôture quotidienne du VIX |
 | `/api/v1/fomc_next`      | GET     | Prochaine réunion FOMC |
+| `/api/v1/powell_speech`  | GET     | Prochain discours de Jerome Powell |
 
 Exemple de réponse :
 
@@ -75,6 +76,17 @@ Exemple de réponse :
   "date": "2024-07-31",
   "time": "18:00",
   "title": "FOMC Meeting",
+  "url": "https://www.federalreserve.gov/..."
+}
+```
+
+Exemple pour `/api/v1/powell_speech` :
+
+```json
+{
+  "date": "2024-08-15",
+  "time": "14:30",
+  "title": "Speech by Chair Powell",
   "url": "https://www.federalreserve.gov/..."
 }
 ```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from .crud import (
     fetch_fed_rate,
     fetch_vix,
     fetch_fomc_next,
+    fetch_powell_speech,
 )
 from .schemas import (
     MarketIndices,
@@ -15,6 +16,7 @@ from .schemas import (
     FedRate,
     VIXClose,
     FomcNext,
+    PowellSpeech,
 )
 
 app = FastAPI(title="Goldapp API")
@@ -88,6 +90,16 @@ def get_fomc_next():
     """Return the next upcoming FOMC meeting."""
     try:
         data = fetch_fomc_next()
+    except Exception:
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    return data
+
+
+@app.get("/api/v1/powell_speech", response_model=PowellSpeech | None)
+def get_powell_speech():
+    """Return details of the next Powell speech."""
+    try:
+        data = fetch_powell_speech()
     except Exception:
         raise HTTPException(status_code=503, detail="Service Unavailable")
     return data

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -53,3 +53,12 @@ class FomcNext(BaseModel):
     time: str  # HH:MM (UTC)
     title: str
     url: str
+
+
+class PowellSpeech(BaseModel):
+    """Represent the next scheduled speech from Jerome Powell."""
+
+    date: str  # YYYY-MM-DD
+    time: str  # HH:MM (UTC)
+    title: str
+    url: str

--- a/backend/tests/test_endpoints_http.py
+++ b/backend/tests/test_endpoints_http.py
@@ -161,3 +161,25 @@ async def test_api_fomc_next_error(mocker):
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/api/v1/fomc_next")
     assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_api_powell_speech_ok(mocker):
+    from app.schemas import PowellSpeech
+
+    payload = PowellSpeech(date="2099-01-01", time="12:00", title="Speech", url="u")
+    mocker.patch("app.main.fetch_powell_speech", return_value=payload)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/powell_speech")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Speech"
+
+
+@pytest.mark.asyncio
+async def test_api_powell_speech_error(mocker):
+    mocker.patch("app.main.fetch_powell_speech", side_effect=RuntimeError)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/powell_speech")
+    assert resp.status_code == 503

--- a/backend/tests/test_powell_speech.py
+++ b/backend/tests/test_powell_speech.py
@@ -1,0 +1,82 @@
+import requests
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.crud import fetch_powell_speech, POWELL_SPEECH_CACHE
+from app.schemas import PowellSpeech
+
+
+def _mock_response(mocker, text: str):
+    resp = mocker.Mock()
+    resp.text = text
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_powell_speech_success(mocker):
+    POWELL_SPEECH_CACHE.clear()
+    now = datetime.utcnow()
+    dt1 = (now + timedelta(days=1)).strftime("%a, %d %b %Y %H:%M:%S +0000")
+    xml = (
+        "<rss><channel>"
+        f"<item><title>Powell remarks</title><link>https://a</link><description>x</description><pubDate>{dt1}</pubDate></item>"
+        "</channel></rss>"
+    )
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+
+    data = fetch_powell_speech()
+
+    assert isinstance(data, PowellSpeech)
+    assert data.title == "Powell remarks"
+    assert data.url == "https://a"
+    assert data.date == (now + timedelta(days=1)).strftime("%Y-%m-%d")
+    assert data.time == (now + timedelta(days=1)).strftime("%H:%M")
+
+
+def test_powell_speech_none(mocker):
+    POWELL_SPEECH_CACHE.clear()
+    now = datetime.utcnow()
+    past = (now - timedelta(days=1)).strftime("%a, %d %b %Y %H:%M:%S +0000")
+    xml = (
+        "<rss><channel>"
+        f"<item><title>No powell</title><link>x</link><description></description><pubDate>{past}</pubDate></item>"
+        "</channel></rss>"
+    )
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+
+    data = fetch_powell_speech()
+
+    assert data is None
+
+
+def test_powell_speech_error(mocker):
+    POWELL_SPEECH_CACHE.clear()
+    mocker.patch("requests.get", side_effect=requests.RequestException)
+    with pytest.raises(RuntimeError):
+        fetch_powell_speech()
+
+
+def test_powell_speech_parse_error(mocker):
+    POWELL_SPEECH_CACHE.clear()
+    xml = "<rss><channel><item>"
+    mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+    with pytest.raises(RuntimeError):
+        fetch_powell_speech()
+
+
+def test_powell_speech_cache(mocker):
+    POWELL_SPEECH_CACHE.clear()
+    future = (datetime.utcnow() + timedelta(days=1)).strftime("%a, %d %b %Y %H:%M:%S +0000")
+    xml = (
+        "<rss><channel>"
+        f"<item><title>Powell</title><link>u</link><description></description><pubDate>{future}</pubDate></item>"
+        "</channel></rss>"
+    )
+    mock_get = mocker.patch("requests.get", return_value=_mock_response(mocker, xml))
+
+    first = fetch_powell_speech()
+    second = fetch_powell_speech()
+
+    assert first is second
+    assert mock_get.call_count == 1


### PR DESCRIPTION
## Summary
- add PowellSpeech model and caches
- expose `/api/v1/powell_speech` route
- implement RSS parsing for next Powell speech
- document new endpoint with example
- test CRUD logic, cache and HTTP route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd8ca99483248e0eac6dfc9a79e4